### PR TITLE
Fix RGBA slider label and value in UI docs

### DIFF
--- a/docs/docs/ui_docs_5.glsl
+++ b/docs/docs/ui_docs_5.glsl
@@ -194,10 +194,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 
         {
             s2h_printTxt(ui, _SPACE, _SPACE);
-            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider0);
+            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider1);
             s2h_printTxt(ui, _SPACE, _s, _2, _h, _UNDERSCORE);
             s2h_printTxt(ui, _s, _l, _i, _d, _e, _r);
-            s2h_printTxt(ui, _R, _G, _B);
+            s2h_printTxt(ui, _R, _G, _B, _A);
             s2h_printLF(ui);
             s2h_printLF(ui);
             s2h_printLF(ui);

--- a/docs/docs/ui_docs_5.hlsl
+++ b/docs/docs/ui_docs_5.hlsl
@@ -159,10 +159,10 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
 
         {
             s2h_printTxt(ui, _SPACE, _SPACE);
-            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider0);
+            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider1);
             s2h_printTxt(ui, _SPACE, _s, _2, _h, _UNDERSCORE);
             s2h_printTxt(ui, _s, _l, _i, _d, _e, _r);
-            s2h_printTxt(ui, _R, _G, _B);
+            s2h_printTxt(ui, _R, _G, _B, _A);
             s2h_printLF(ui);
             s2h_printLF(ui);
             s2h_printLF(ui);

--- a/docs_src/UI_docs.hlsl
+++ b/docs_src/UI_docs.hlsl
@@ -145,10 +145,10 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
 #if SUB_CATEGORY == 5  // sliderRGBA
         {
             s2h_printTxt(ui, _SPACE, _SPACE);
-            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider0);
+            s2h_sliderRGBA(ui, 8u, UIState[0].colorSlider1);
             s2h_printTxt(ui, _SPACE, _s, _2, _h, _UNDERSCORE);
             s2h_printTxt(ui, _s, _l, _i, _d, _e, _r);
-            s2h_printTxt(ui, _R, _G, _B);
+            s2h_printTxt(ui, _R, _G, _B, _A);
             s2h_printLF(ui);
             s2h_printLF(ui);
             s2h_printLF(ui);


### PR DESCRIPTION
Fixed a label to be "RGBA" instead of "RGB",
And I believe the value referenced should be `colorSlider1`, as per gigi example.