### PR TITLE
Fix non-antialiased rendering in 3D docs

### DIFF
--- a/docs/docs/3d_docs_0.glsl
+++ b/docs/docs/3d_docs_0.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_0.hlsl
+++ b/docs/docs/3d_docs_0.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_1.glsl
+++ b/docs/docs/3d_docs_1.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_1.hlsl
+++ b/docs/docs/3d_docs_1.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_2.glsl
+++ b/docs/docs/3d_docs_2.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_2.hlsl
+++ b/docs/docs/3d_docs_2.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_3.glsl
+++ b/docs/docs/3d_docs_3.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_3.hlsl
+++ b/docs/docs/3d_docs_3.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_4.glsl
+++ b/docs/docs/3d_docs_4.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_4.hlsl
+++ b/docs/docs/3d_docs_4.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_5.glsl
+++ b/docs/docs/3d_docs_5.glsl
@@ -166,7 +166,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, ((u_worldFromView * vec4(0, 0, 0, 1)).xyz), normalize(worldPos - context.ro));
+        vec3 ro = ((u_worldFromView * vec4(0, 0, 0, 1)).xyz);
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = vec4(computeSkyColor(context), 1);

--- a/docs/docs/3d_docs_5.hlsl
+++ b/docs/docs/3d_docs_5.hlsl
@@ -131,7 +131,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);

--- a/docs_src/3D_docs.hlsl
+++ b/docs_src/3D_docs.hlsl
@@ -117,7 +117,8 @@ void mainImage( out float4 fragColor, in float2 fragCoord )
             worldPos = worldPosHom.xyz / worldPosHom.w;
         }
 
-        s2h_init(context, S2S_CAMERA_POS(), normalize(worldPos - context.ro));
+        vec3 ro = S2S_CAMERA_POS();
+        s2h_init(context, ro, normalize(worldPos - ro));
 
         // uncomment to composite with former pass
         context.dstColor = float4(computeSkyColor(context), 1);


### PR DESCRIPTION
Currently, if you set `AA` to 1 in the provided 3D examples, the scene won't be rendered, because `context.ro` isn't set at the time of the first antialiasing pass. This fixes it.